### PR TITLE
fix: Save attachments in a dedicated 'attachments' directory

### DIFF
--- a/chat-history.py
+++ b/chat-history.py
@@ -186,7 +186,6 @@ def merge_sessions(sessions):
     return session
 
 
-# TODO: Extract this.
 def received_files_import(context, media_destination_path, path):
     sessions = []
     for identifier in os.listdir(path):

--- a/chat-history.py
+++ b/chat-history.py
@@ -186,6 +186,7 @@ def merge_sessions(sessions):
     return session
 
 
+# TODO: Extract this.
 def received_files_import(context, media_destination_path, path):
     sessions = []
     for identifier in os.listdir(path):
@@ -211,7 +212,6 @@ def received_files_import(context, media_destination_path, path):
 
 IMPORTERS = {
     "whatsapp_ios": importers.whatsapp.ios,
-    # "whatsapp_android": importers.whatsapp.android,
     "received_files": received_files_import,
     "msn_messenger": importers.msn.msn_messenger,
     "text_archive": importers.text.text_archive,
@@ -226,9 +226,11 @@ def main():
     options = parser.parse_args()
 
     configuration = Configuration(options.configuration)
+    attachments_directory = os.path.join(configuration.configuration["output"], "attachments")
     if os.path.exists(configuration.configuration["output"]):
         shutil.rmtree(configuration.configuration["output"])
     os.makedirs(configuration.configuration["output"])
+    os.makedirs(attachments_directory)
 
     people = People()
     for person in configuration.configuration["people"]:
@@ -249,8 +251,8 @@ def main():
             exit()
         for path in paths:
             logging.info("Importing '%s'...", path)
-            for session in importer(context, configuration.configuration["output"], path):
-                events = detect_images(configuration.configuration["output"], session.events)
+            for session in importer(context, attachments_directory, path):
+                events = detect_images(attachments_directory, session.events)
                 events = list(detect_videos(events))
                 sessions.append(model.Session(sources=session.sources, people=session.people, events=events))
 

--- a/templates/conversation.html
+++ b/templates/conversation.html
@@ -40,7 +40,7 @@
 
                     <div class="images">
                         {% for batch in conversation.batches %}{% for message in batch.messages %}{% if message.type == EventType.IMAGE %}
-                            <a onclick="location.href='#{{ message.id }}'; return false;" target="_blank"><img src="{{ message.content }}" width="{{ message.width }}" height="{{ message.height }}"></a>
+                            <a onclick="location.href='#{{ message.id }}'; return false;" target="_blank"><img src="attachments/{{ message.content }}" width="{{ message.width }}" height="{{ message.height }}"></a>
                         {% endif %}{% endfor %}{% endfor %}
                     </div>
 
@@ -67,11 +67,11 @@
                                         </div>
                                     {% elif message.type == EventType.IMAGE %}
                                         <a id="{{ message.id }}" href="{{ message.content }}" title="{{ message.date.strftime('%-d %B %Y, %H:%M:%S') }}">
-                                            <img src="{{ message.content }}" width="{{ message.width }}" height="{{ message.height }}">
+                                            <img src="attachments/{{ message.content }}" width="{{ message.width }}" height="{{ message.height }}">
                                         </a>
                                     {% elif message.type == EventType.VIDEO %}
                                         <video controls>
-                                            <source src="{{ message.content }}" type="{{ message.mimetype }}">
+                                            <source src="attachments/{{ message.content }}" type="{{ message.mimetype }}">
                                             Your browser does not support the video tag.
                                         </video>
                                     {% else %}


### PR DESCRIPTION
This changes writes all attachments to a new 'attachments' subdirectory in the output folder to avoid cluttering the top-level directory.