### PR TITLE
fix: Use UUIDs for conversation file names

### DIFF
--- a/chat-history.py
+++ b/chat-history.py
@@ -249,7 +249,7 @@ def main():
         with open(OUTPUT_INDEX_PATH, "w") as fh:
             fh.write(conversation_template.render(conversations=conversations, EventType=model.EventType))
         for conversation in conversations:
-            with open(f"{conversation.stable_identifier}.html", "w") as fh:
+            with open(f"{conversation.id}.html", "w") as fh:
                 fh.write(conversation_template.render(conversations=conversations, conversation=conversation, EventType=model.EventType))
 
     logging.info("Chat history written to '%s'.", OUTPUT_INDEX_PATH)

--- a/model.py
+++ b/model.py
@@ -86,16 +86,6 @@ class Conversation(Object):
         people = sorted(self.people, key=lambda x: x.name)
         return ", ".join([person.name for person in people if not person.is_primary])
 
-    @property
-    def stable_identifier(self):
-        people = sorted(self.people, key=lambda x: x.name)
-        stable_identifier = "-".join([person.name.lower() for person in people if not person.is_primary])
-        stable_identifier = utilities.remove_control_characters(stable_identifier)
-        stable_identifier = stable_identifier.strip()
-        stable_identifier = re.sub(r"[\\\/,\s\+\- ]+", "-", stable_identifier)
-        stable_identifier = re.sub(r"\-+", "-", stable_identifier)
-        return stable_identifier[:100]
-
 
 class Event(object):
 

--- a/templates/conversation.html
+++ b/templates/conversation.html
@@ -18,7 +18,7 @@
                         <li>
                             <a
                                 title="{{ loop_conversation.sources | join(", ") }}"
-                                href="{{ loop_conversation.stable_identifier }}.html"
+                                href="{{ loop_conversation.id }}.html"
                                 class="{% if conversation and loop_conversation.id == conversation.id %}active{% endif %}">
                                 {{ loop_conversation.name }}
                                 <button onclick="copyToClipboard('{{ loop_conversation.configuration | replace("\n", "\\n") | replace("\"", "&quot;") | replace("'", "\\'") }}')">Copy</button>


### PR DESCRIPTION
We were previously attempting to generate identifiers based on the participants in the conversations. This wasn't guaranteed to be unique, and represents unnecessary work.